### PR TITLE
Define MPI_ABI and remove MPI_ABI_VERSION

### DIFF
--- a/.github/workflows/mpi4py.yml
+++ b/.github/workflows/mpi4py.yml
@@ -49,7 +49,6 @@ jobs:
     - name: Install mpi4py
       run: python -m pip install ./mpi4py
       env:
-        CPPFLAGS: "-DMPI_ABI=1"
         CFLAGS: "-O0"
 
     - name: Check mpi4py symbols
@@ -84,7 +83,6 @@ jobs:
     - name: Install mpi4py (small-count)
       run: python -m pip install ./mpi4py
       env:
-        CPPFLAGS: "-DMPI_ABI=1"
         CFLAGS: "-O0"
 
     - name: Check mpi4py symbols (small-count)

--- a/mpi.h
+++ b/mpi.h
@@ -13,9 +13,6 @@ extern "C" {
 #define MPI_VERSION    4
 #define MPI_SUBVERSION 2
 
-#define MPI_ABI_VERSION    1
-#define MPI_ABI_SUBVERSION 0
-
 /* MPI_Aint is defined to be intptr_t (or equivalent to it, if compiler support is absent).
  * The only acceptable alternative to intptr_t is the C89 type equivalent to it. */
 #if !defined(MPI_ABI_Aint)

--- a/mpi.h
+++ b/mpi.h
@@ -7,6 +7,9 @@
 extern "C" {
 #endif
 
+#undef  MPI_ABI
+#define MPI_ABI 1
+
 #define MPI_VERSION    4
 #define MPI_SUBVERSION 2
 


### PR DESCRIPTION
I'm opening this PR to discuss two somewhat separate but related concepts.

# Define `MPI_ABI` macro
* We need a way to perform conditional compilation under the ABI. This can be as trivial as `#define MPI_ABI 1`  if the implementation supports the ABI. This is what MPICH has implemented so far. This is also mpi4py is already taking advantage of. This PR the definition of `MPI_ABI` to the stubs `mpi.h`.
* As this is primarily and so far about conditional compilation in C, this definition does not apply to Fortran.

# Remove `MPI_ABI_VERSION` and `MPI_ABI_VERSION`
* @hzhou has expressed his opposition to adding `MPI_ABI_(SUB)VERSION` to `mpi.h` as an unnecessary leakage of ABI details to the user. 
* @dalcinl has also expressed concerns about whether `MPI_ABI_(SUB)VERSION` is ultimately useful, as the each MPI standard implicitly defines the backward compatibility guarantees from the set of added and removed symbols from each MPI standard release.