### PR TITLE
CI: Update after changes in mpi4py improving ABI support

### DIFF
--- a/.github/workflows/mpi4py.yml
+++ b/.github/workflows/mpi4py.yml
@@ -49,7 +49,6 @@ jobs:
     - name: Install mpi4py
       run: python -m pip install ./mpi4py
       env:
-        CPPFLAGS: "-DMPI_ABI=1"
         CFLAGS: "-O0"
 
     - name: Check mpi4py symbols
@@ -84,7 +83,6 @@ jobs:
     - name: Install mpi4py (small-count)
       run: python -m pip install ./mpi4py
       env:
-        CPPFLAGS: "-DMPI_ABI=1"
         CFLAGS: "-O0"
 
     - name: Check mpi4py symbols (small-count)


### PR DESCRIPTION
See https://github.com/mpi4py/mpi4py/commit/5e37cb2284353f31ff238979728f67394afd3ccc, adopting suggestion from https://github.com/mpiwg-abi/header_and_stub_library/pull/29#issuecomment-2019771355:

```c
#if defined(MPI_ABI_VERSION)
#  if MPI_ABI_VERSION >= 1
#    define PyMPI_ABI 1
#  endif
#endif
```