### PR TITLE
mpi.h: Update value of MPI_DISPLACEMENT_CURRENT to -1

### DIFF
--- a/mpi.h
+++ b/mpi.h
@@ -425,7 +425,7 @@ enum {
 };
 
 /* File Operation Constants */
-#define MPI_DISPLACEMENT_CURRENT       ((MPI_Offset)-54278278)
+#define MPI_DISPLACEMENT_CURRENT       ((MPI_Offset)-1)
 
 /* Predefined Attribute Keys */
 enum {


### PR DESCRIPTION
The original value of this constant (borrowed from ROMIO) has no significant meaning. It functionally can be any negative integer. ANL suggests `-1` for simplicity.